### PR TITLE
Initial re-write of README.md for alt:V + document trigger API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-### NOTE: This readme is from the rage-rpc repo. I have not yet updated it for the alt:V api.
 
 * [Motivation](#motivation)
 * [Installation](#installation)
@@ -10,23 +9,23 @@
     * [Universal](#universal)
         * [register(name, callback)](#registername-callback)
         * [unregister(name)](#unregistername)
-        * [call(name, args)](#callname-args)
-        * [callServer(name, args)](#callservername-args)
+        * [call(name, args, options)](#callname-args-options)
+        * [callServer(name, args, options)](#callservername-args-options)
         * [on(name, callback)](#onname-callback)
         * [off(name, callback)](#offname-callback)
         * [trigger(name, args)](#triggername-args)
         * [triggerServer(name, args)](#triggerservername-args)
     * [Server-side](#server-side-3)
         * [callClient(player, name, args)](#callclientplayer-name-args)
-        * [callBrowsers(player, name, args)](#callbrowsersplayer-name-args)
+        * [callBrowsers(player, name, args)](#callbrowsersplayer-name-args-options)
         * [triggerClient(player, name, args)](#triggerclientplayer-name-args)
         * [triggerBrowsers(player, name, args)](#triggerbrowsersplayer-name-args)
     * [Client-side](#client-side-2)
-        * [callBrowser(browser, name, args)](#callbrowserbrowser-name-args)
+        * [callBrowser(browser, name, args)](#callbrowserbrowser-name-args-options)
         * [triggerBrowser(browser, name, args)](#triggerbrowserbrowser-name-args)
     * [CEF or Client-side](#cef-or-client-side)
-        * [callBrowsers(name, args)](#callbrowsersname-args)
-        * [callClient(name, args)](#callclientname-args)
+        * [callBrowsers(name, args)](#callbrowsersname-args-options)
+        * [callClient(name, args)](#callclientname-args-options)
         * [triggerBrowsers(name, args)](#triggerbrowsersname-args)
         * [triggerClient(name, args)](#triggerclientname-args)
 * [Options](#options)
@@ -35,6 +34,17 @@
 
 ---
 
+## Motivation
+
+A very common workflow when developing with any kind of client-server platform is not only sending data between the server and clients, but also receiving data back after performing some kind of action. An example would be a client asking for information from a database in order to display to the user. One technique to achieve this is called [remote procedure calls (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call) which allows one application context to call code in a completely separate context and return the result back to the caller, as if it were local to begin with.
+
+In alt:V, this kind of functionality is not supported natively. In order for a player to ask something of the server, the server must set up an event handler that the player calls remotely, then the server does its processing and calls _another_ event handler that resides on the client. There are many pitfalls to this approach, including but not limited to messy code and false identification (am i sending the response to the right caller instance?). Natively, the server cannot directly communicate with CEF instances at all. You have to route *all requests* through the client. Suddenly, you have 16 different events to handle one simple data request. It's horrible. And when your codebase starts growing, it becomes a huge hassle to deal with.
+
+This is pretty much what everybody has learned to deal with, until now. `altv-rpc` simplifies two-way communication between the alt:V server, client, and browser instances by providing a easy-to-use API for calling remote code and retrieving results. **Any context can call a function that resides in any other context and immediately get access to its return value without messing with events.** This means any CEF instance can call code on the server, the client, or any other CEF instances and easily see the result.
+
+---
+
+
 ## Installation
 
 #### Option 1
@@ -42,37 +52,38 @@
 You can install via [npm](https://github.com/npm/cli)
 
 ```
-npm i -S rage-rpc
+npm i -S altv-rpc
 ```
 
-From here, you can simply require the package in any RAGE context:
+From here, you can simply require the package in any alt:V context:
 
 ```javascript
-const rpc = require('rage-rpc');
+import * as rpc from 'altv-rpc';
 
 rpc.register('hi', () => 'hello!');
 ```
 
 #### Option 2
 
-In the `dist/` folder of this repository is a single minified JS file that you can download and require into any RAGE context. It works the same as the above option, but you'll have to manually redownload the file when new versions are released.
+In the `dist/` folder of this repository are two minified JS files that you can download and require into any alt:V context, `altv-rpc.mjs` and `altv-rpc-browser.js`. They work the same as the above option, but you'll have to manually redownload the files when new versions are released.
 
 ```javascript
-const rpc = require('./rage-rpc.min.js');
+import rpc from './altv-rpc.mjs'
 
 rpc.register('hi', () => 'hello!');
 ```
 
 #### Option 3 (Browser Only)
 
-In order to use `require` in the browser, you'll need either an AMD loader or some kind of bundler like Webpack. If those options don't suit your project, you can load the file into browser contexts with just a script tag before the code you use it in. It will expose a global `rpc` variable that you can use on your page.
+You can load `altv-rpc-browser.js` into browser contexts with just a script tag before the code you use it in. It will expose a global `rpc` variable that you can use on your page.
 
 ```html
 <html>
     <head>
         <title>My CEF Page</title>
-        <script type="text/javascript" src="./rage-rpc.min.js"></script>
+        <script type="text/javascript" src="./altv-rpc-browser.js"></script>
         <script type="text/javascript">
+            rpc.init('yourNamespaceHere')
             rpc.register('hi', () => 'hello from cef!');
             
             // ...
@@ -80,6 +91,40 @@ In order to use `require` in the browser, you'll need either an AMD loader or so
     </head>
 </html>
 ```
+
+### Namespace Setup
+
+You must declare a namespace once within each alt:V server or client module, and you must individually declare this namespace within each CEF browser in order to use `altv-rpc`.
+
+#### Server or Client
+```js
+import rpc from 'altv-rpc';
+// call rpc.init() only once per server/client module:
+rpc.init('yourNamespaceHere')
+```
+
+#### Browser
+```html
+        <!-- ... -->
+        <script type="text/javascript" src="./altv-rpc-browser.js"></script>
+        <script type="text/javascript">
+            // call rpc.init() within each browser you wish to use:
+            rpc.init('yourNamespaceHere')
+            // ...
+        </script>
+        <!-- ... -->
+```
+
+In order to register a browser to enable it to use `altv-rpc`, you must use `rpc.addWebView()` upon creating the WebView instance on client-side:
+
+```js
+// client-side...
+const browser = new alt.WebView('http://resource/client/path/to/browser.html');
+rpc.addWebView(browser)
+```
+
+---
+
 
 ## Examples
 
@@ -89,16 +134,18 @@ In order to use `require` in the browser, you'll need either an AMD loader or so
 
 ##### Client-side
 ```javascript
-const rpc = require('rage-rpc');
+import * as rpc from 'altv-rpc';
+import * as native from 'natives';
 
-rpc.register('getIsClimbing', () => mp.players.local.isClimbing());
+const localPlayer = alt.Player.local.scriptID;
+rpc.register('getIsClimbing', () => native.isPlayerClimbing(localPlayer));
 ```
 
 ##### Server-side
 ```javascript
-const rpc = require('rage-rpc');
+import * as rpc from 'altv-rpc';
 
-const player = mp.players.at(0);
+const player = alt.Player.getByID(0);
 
 rpc.callClient(player, 'getIsClimbing').then(climbing => {
     if(climbing){
@@ -122,29 +169,29 @@ const isClimbing = await rpc.callClient(player, 'getIsClimbing');
 
 ##### Server-side
 ```javascript
-const rpc = require('rage-rpc');
+import * as rpc from 'altv-rpc';
 
-rpc.register('getAllLicensePlates', () => mp.vehicles.toArray().map(vehicle => vehicle.numberPlate));
+rpc.register('getAllLicensePlates', () => alt.Vehicle.all.map(vehicle => vehicle.numberPlateText));
 ```
 
 ##### Client-side
 ```javascript
 // even if not using RPC on the client, it must be required somewhere before CEF can send any events
-require('rage-rpc');
+import * as rpc from 'altv-rpc';
 ```
 
 ##### Browser
 ```javascript
-const rpc = require('rage-rpc');
+// ensure altv-rpc-browser.js is imported within browser...
 
 rpc.callServer('getAllLicensePlates').then(plates => {
     alert(plates.join(', '));
 });
 ```
 
-With `rage-rpc`, CEF can directly communicate with the server and vice-versa, without having to pass everything through the client-side JS.
+With `altv-rpc`, CEF can directly communicate with the server and vice-versa, without having to pass everything through the client-side JS.
 
-###### In vanilla RAGE, you would have to set up multiple events for sending/receiving on the client-side, call them from CEF, then resend the data to the server and back. It's a huge hassle.
+###### In vanilla alt:V, you would have to set up multiple events for sending/receiving on the client-side, call them from CEF, then resend the data to the server and back. It's a huge hassle.
 
 ---
 
@@ -154,7 +201,7 @@ With `rage-rpc`, CEF can directly communicate with the server and vice-versa, wi
 
 ##### Server-side
 ```javascript
-const rpc = require('rage-rpc');
+import * as rpc from 'altv-rpc';
 
 rpc.register('log', (message, info) => {
     /*
@@ -170,7 +217,8 @@ rpc.register('log', (message, info) => {
 
 ##### Client-side OR Browser
 ```javascript
-const rpc = require('rage-rpc');
+import * as rpc from 'altv-rpc';
+// OR ensure altv-rpc-browser.js is imported within browser...
 
 function log(message){
     return rpc.callServer('log', message);
@@ -187,11 +235,11 @@ log("Hello again!").then(() => {
 });
 ```
 
-**Note:** Once any side of the game registers a procedure, any context can immediately start accessing it. You could call `rpc.callServer('log', message);` from any CEF instance or anywhere in the client without any further setup.
+**Note:** Once any side of the game registers a procedure, any context can immediately start accessing it, assuming you have used `rpc.init()` at least once within that context. You could call `rpc.callServer('log', message);` from any CEF instance or anywhere in the client without any further setup.
 
 ## API
 
-This library is universal to RAGE, which means you can load the same package into all 3 contexts: browser, client JS, and server JS.
+This library is universal to alt:V, which means you can load the same package into all 3 contexts: browser, client JS, and server JS.
 
 There are only 7 functions that you can use almost anywhere around your game. However, depending on the current context, the usage of some functions might differ slightly.
 
@@ -213,7 +261,7 @@ The return value of the `callback` will be sent back to the caller, even if it f
     * `info` [object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) - Various information about the caller.
         * `id` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The internal ID used to keep track of this request.
         * `environment` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The caller's environment. Can be `cef`, `client`, or `server`.
-        * `player` [Player](https://wiki.rage.mp/index.php?title=Server-side_functions#Player) - The caller. *Only exists in the server context if remotely called from `cef` or `client`.*
+        * `player` [Player](https://altmp.github.io/altv-typings/classes/_alt_server_.player.html) - The caller. *Only exists in the server context if remotely called from `cef` or `client`.*
 
 ##### Examples
 
@@ -285,13 +333,13 @@ Calls a procedure that has been registered on the server.
 
 Server-side:
 ```javascript
-rpc.register('getWeather', () => mp.world.weather);
+rpc.register('getNetTime', () => alt.getNetTime());
 ```
 
 Client-side OR Browser OR Server:
 ```javascript
-rpc.callServer('getWeather').then(weather => {
-    mp.gui.chat.push(`The current weather is ${weather}.`);
+rpc.callServer('getNetTime').then(netTime => {
+    alt.log(`The current netTime is ${netTime}.`);
 }).catch(err => {
     // handle error
 });
@@ -299,13 +347,85 @@ rpc.callServer('getWeather').then(weather => {
 
 ###### Returns [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) resolving or failing due to the procedure's result. If the procedure called does not exist, `PROCEDURE_NOT_FOUND` will be thrown.
 
+
+#### on(name, callback)
+
+Declares an event in the current context.
+
+Unlike `register()`, `on()` will not return a result to the client, and is purely a one-way event.
+
+##### Parameters
+
+* `name` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The unique identifier, relative to the current context, of the procedure.
+* `callback` [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) - The procedure. This function will receive 2 arguments.
+    * `args` - The arguments that were provided by the caller. This parameter's type will be the same that was sent by the caller. `undefined` if no arguments were sent.
+    * `info` [object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) - Various information about the caller.
+        * `id` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The internal ID used to keep track of this request.
+        * `environment` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The caller's environment. Can be `cef`, `client`, or `server`.
+        * `player` [Player](https://altmp.github.io/altv-typings/classes/_alt_server_.player.html) - The caller. *Only exists in the server context if remotely called from `cef` or `client`.*
+
+##### Example
+
+Client:
+
+```javascript
+let deathBrowser;
+const showDeathBrowser = () => {
+    if (!deathBrowser){
+        new alt.WebView('http://resource/client/path/to/deathBrowser.html');
+        rpc.addWebView(deathBrowser);
+    }
+}
+rpc.on('openDeathBrowser', showDeathBrowser);
+```
+
+Server:
+```javascript
+alt.on('playerDeath', (player) => {
+    rpc.triggerClient('openDeathBrowser');
+})
+```
+
+#### off(name, callback)
+
+Removes an event from the current context.
+
+##### Example
+
+Client:
+
+```javascript
+rpc.off('openDeathBrowser', showDeathBrowser);
+```
+
+#### trigger(name, args)
+
+Trigger an event that has been declared in the current context.
+
+#### triggerServer(name, args)
+
+Trigger an event that has been declared on the server.
+
+##### Example
+
+Server:
+```javascript
+let loginFailsThisSession = 0;
+rpc.on('loginFail', () => { loginFailsThisSession++ });
+```
+Any context:
+```javascript
+let loginFailsThisSession = 0;
+rpc.triggerServer('loginFail');
+```
+
 ### Server-side
 
 #### callClient(player, name, args?)
 
 Calls a procedure that has been registered on a specific client.
 
-* `player` [Player](https://wiki.rage.mp/index.php?title=Server-side_functions#Player) - The player to call the procedure on.
+* `player` [Player](https://altmp.github.io/altv-typings/classes/_alt_server_.player.html) - The player to call the procedure on.
 * `name` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The name of the registered procedure.
 * `args?` - Optional arguments to pass to the procedure. Must be JSON-able. Use an array or object to pass multiple arguments.
 * `options?` - Optional [options](#options) to control how the procedure is called.
@@ -315,13 +435,13 @@ Calls a procedure that has been registered on a specific client.
 Client-side:
 ```javascript
 rpc.register('toggleChat', toggle => {
-    mp.gui.chat.show(toggle);
+    yourToggleChatFunc(toggle);
 });
 ```
 
 Server-side:
 ```javascript
-mp.players.forEach(player => {
+alt.Player.all.forEach(player => {
     rpc.callClient(player, 'toggleChat', false);
 });
 ```
@@ -334,7 +454,7 @@ Calls a procedure that has been registered in any CEF instance on a specific cli
 
 Any CEF instance can register the procedure. The client will iterate through each instance and call the procedure on the first instance that it exists on.
 
-* `player` [Player](https://wiki.rage.mp/index.php?title=Server-side_functions#Player) - The player to call the procedure on.
+* `player` [Player](https://altmp.github.io/altv-typings/classes/_alt_server_.player.html) - The player to call the procedure on.
 * `name` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The name of the registered procedure.
 * `args?` - Optional arguments to pass to the procedure. Must be JSON-able. Use an array or object to pass multiple arguments.
 * `options?` - Optional [options](#options) to control how the procedure is called.
@@ -358,13 +478,21 @@ mp.players.forEach(player => {
 
 ###### Returns [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) resolving or failing due to the procedure's result. If the procedure called does not exist, `PROCEDURE_NOT_FOUND` will be thrown.
 
+#### triggerClient(player, name, args)
+
+Trigger an event that has been declared on the client.
+
+#### triggerBrowsers(player, name, args)
+
+Iterates through every browser and triggers an event that has been declared within that CEF instance.
+
 ### Client-side
 
 #### callBrowser(browser, name, args?, options?)
 
 Calls a procedure that has been registered in a specific CEF instance.
 
-* `browser` [Browser](https://wiki.rage.mp/index.php?title=Client-side_functions#Browser) - The browser to call the procedure on.
+* `browser` [Browser](https://altmp.github.io/altv-typings/classes/_alt_client_.webview.html) - The browser to call the procedure on.
 * `name` [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) - The name of the registered procedure.
 * `args?` - Optional arguments to pass to the procedure. Must be JSON-able. Use an array or object to pass multiple arguments.
 * `options?` - Optional [options](#options) to control how the procedure is called.
@@ -381,16 +509,20 @@ rpc.register('getInputValue', () => {
 
 Client-side:
 ```javascript
-const browser = mp.browsers.at(0);
+const browser = new alt.WebView('http://resource/client/path/to/browser.html');
 
 rpc.callBrowser(browser, 'getInputValue').then(value => {
-    mp.gui.chat.push(`The CEF input value is: ${value}`);
+    alt.log(`The CEF input value is: ${value}`);
 }).catch(err => {
     // handle errors
 });
 ```
 
 ###### Returns [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) resolving or failing due to the procedure's result. If the procedure called does not exist, `PROCEDURE_NOT_FOUND` will be thrown.
+
+#### triggerBrowser(browser, name, args)
+
+Trigger an event that has been declared within a specific browser.
 
 ### CEF or Client-side
 
@@ -434,7 +566,7 @@ Calls a procedure that has been registered on the local client.
 Client-side:
 ```javascript
 rpc.register('toggleChat', toggle => {
-    mp.gui.chat.show(toggle);
+    yourToggleChatFunc(toggle);
 });
 ```
 
@@ -445,6 +577,14 @@ rpc.callClient('toggleChat', false);
 
 ###### Returns [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) resolving or failing due to the procedure's result. If the procedure called does not exist, `PROCEDURE_NOT_FOUND` will be thrown.
 
+#### triggerBrowsers(name, args)
+
+Iterates through every browser and triggers an event that has been declared within that CEF instance.
+
+#### triggerClient(name, args)
+
+Trigger an event that has been declared on the client.
+
 ## Options
 
 For remote procedure calling functions, there are optional options you can pass as the last parameter:
@@ -454,11 +594,20 @@ For remote procedure calling functions, there are optional options you can pass 
 
 ## Events
 
-You can now use rage-rpc as a full on replacement for mp.events. API functions that start with "trigger" use the same syntax as the ones that start with "call", except they do not return anything. They call remote events on any context where there can be many handlers or none.
+You can now use altv-rpc as a full on replacement for alt:V API functions that start with "on/off" and use the same syntax as the ones that start with "emit", except they do not return anything. They call remote events on any context where there can be many handlers or none.
 
 ## Changelog
 
 Check the releases tab for an up-to-date changelog.
+
+#### 0.1.3
+
+* FIX: free up finished incoming event IDs
+
+#### 0.1.2
+
+* ADD: ability to send events of any size - data is split and re-ordered internally
+* FIX: `altv-rpc-browser.js` now correctly builds in UMD format rather than ESM
 
 #### 0.1.0
 


### PR DESCRIPTION
**Summary**

- Changed all references to RAGE:MP (+ `mp.` API) to refer to alt:V
- Fixed links in table of contents
- Re-added Motivation section - uncertain if this was intended to be carried over, can be dropped if necessary
- Added a setup section covering `rpc.init()` and `rpc.addWebView()`
- Documented on/off/trigger[...] API
- Added a few more examples to support on/off/trigger - some still not documented however
- Changed + new code examples are not fully tested as of yet, and may not be accurate
- Updated changelog to include a summary of recent changes, may need re-wording